### PR TITLE
feature/cards-peek

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Status: In development 🚧 🏁 (Basic TUI and game engine is rdy)
   - (✅) https://github.com/ratatui/ratatui
   - https://github.com/gyscos/cursive
 3. (✅) Basic TUI
-4. Undo functionality + keybind
+4. ~~Undo functionality + keybind~~ (✅) Card peek option (Kinda undo replacement, Undo will come later maybe)
 5. Hint functionality + keybind
 6. Advanced TUI:
   - Splash screen

--- a/src/app/game_window/game_window.rs
+++ b/src/app/game_window/game_window.rs
@@ -13,7 +13,7 @@ use crate::game::{
     card_stock::ICardStock,
     core::{COMPLETE_SEQUENCES_TO_WIN, PILES_AMOUNT},
     game_engine::GameEngine,
-    v2::CardMoveBuilder,
+    v2::{CardMoveBuilder, CardPeek},
 };
 
 use super::{
@@ -31,6 +31,7 @@ pub struct GameWindow<CardStockT: ICardStock> {
     game_engine: GameEngine<CardStockT>,
 
     cursor: GameCursor,
+    card_peeks: Option<[Option<CardPeek>; PILES_AMOUNT]>,
 }
 
 impl<CardStockT: ICardStock> GameWindow<CardStockT> {
@@ -43,6 +44,7 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
         Self {
             game_engine,
             cursor,
+            card_peeks: None,
         }
     }
 
@@ -113,6 +115,7 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
             } else {
                 self.game_engine.perform_move(
                     CardMoveBuilder::from_pile(selected_card_pile_idx)
+                        .using_card(selected_card_idx)
                         .to_card_pile(target_pile_idx)
                         .build(),
                 )
@@ -120,6 +123,10 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
         } else {
             Err(())
         }
+    }
+
+    fn clear_card_peeks(&mut self) {
+        self.card_peeks = None;
     }
 
     fn calc_playable_card_lengths(&self) -> [usize; PILES_AMOUNT] {
@@ -157,6 +164,12 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
             | (KeyModifiers::CONTROL, KeyCode::Char('c') | KeyCode::Char('C')) => {
                 return Some(GameWindowKeyResult::StopTheGame);
             }
+            // [Peek cards]
+            (_, KeyCode::Char('p')) => {
+                self.on_p_pressed();
+
+                return None;
+            }
             // [Arrow navigation]
             (_, KeyCode::Left | KeyCode::Char('h') | KeyCode::Char('a')) => self.on_left_pressed(),
             (_, KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('s')) => self.on_down_pressed(),
@@ -177,6 +190,8 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
             }
         };
 
+        self.clear_card_peeks();
+
         None
     }
     fn on_esc_pressed(&mut self) {
@@ -184,6 +199,9 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
             self.cursor
                 .set_for_card_selection(self.calc_playable_card_lengths());
         }
+    }
+    fn on_p_pressed(&mut self) {
+        self.card_peeks = Some(self.game_engine.get_card_peeks());
     }
     fn on_action_pressed(&mut self) {
         if self.is_selecting_a_card() {
@@ -259,10 +277,10 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
             });
 
             frame.render_stateful_widget(
-                TableauWidget::new(self.cursor),
+                TableauWidget::new(self.cursor, self.card_peeks),
                 tableau_area,
                 &mut self.game_engine.tableau(),
-            )
+            );
         }
     }
 

--- a/src/app/game_window/game_window.rs
+++ b/src/app/game_window/game_window.rs
@@ -327,6 +327,8 @@ impl<CardStockT: ICardStock> GameWindow<CardStockT> {
             line.push_span(Span::from("| Complete sequences: "));
             line.extend(complete_sequence_icons);
 
+            line.push_span(Span::from("| <p> – Peek"));
+
             line
         };
 

--- a/src/app/game_window/widgets/card_pile_widget/card_formatting.rs
+++ b/src/app/game_window/widgets/card_pile_widget/card_formatting.rs
@@ -9,13 +9,14 @@ use crate::{
     app::game_window::game_cursor::{GameCursor, GameCursorMode},
     game::{
         core::{Card, Suit},
-        v2::CardPileV2,
+        v2::{CardPeek, CardPileV2},
     },
 };
 
 pub fn make_card_pile_ascii_cards<'a>(
     cursor: &'a GameCursor,
     pile: &'a mut CardPileV2,
+    card_peek: Option<CardPeek>,
 ) -> Vec<Text<'a>> {
     let mut ascii_cards = vec![];
 
@@ -45,32 +46,41 @@ pub fn make_card_pile_ascii_cards<'a>(
 
     for (card_index, card) in pile.cards().iter().enumerate() {
         let is_last = card_index == cards_len - 1;
+        let is_picked = if let Some(card_peek) = card_peek {
+            card_peek.index == card_index
+        } else {
+            false
+        };
 
-        let border_styling = match idx_card_highlight_start {
-            Some(highlight_start_idx) => match card_index >= highlight_start_idx {
-                true => BorderStyling::Highlight,
-                false => match card.is_opened {
-                    true => BorderStyling::Dim,
-                    false => BorderStyling::Default,
-                },
-            },
-            None => match highlight_last_card && is_last {
-                true => BorderStyling::Highlight,
-                false => match cursor.mode() {
-                    Some(GameCursorMode::CardSelect(_)) => {
-                        assert!(highlight_last_card == false);
-                        BorderStyling::Default
-                    }
-                    Some(GameCursorMode::PileSelect(_)) => match cursor.pile_index() {
-                        Some(index) if index == this_pile_index => BorderStyling::Dim,
-                        _ => BorderStyling::Default,
+        let border_styling = if is_picked {
+            BorderStyling::Picked
+        } else {
+            match idx_card_highlight_start {
+                Some(highlight_start_idx) => match card_index >= highlight_start_idx {
+                    true => BorderStyling::Highlight,
+                    false => match card.is_opened {
+                        true => BorderStyling::Dim,
+                        false => BorderStyling::Default,
                     },
-                    None => {
-                        assert!(false);
-                        BorderStyling::Default
-                    }
                 },
-            },
+                None => match highlight_last_card && is_last {
+                    true => BorderStyling::Highlight,
+                    false => match cursor.mode() {
+                        Some(GameCursorMode::CardSelect(_)) => {
+                            assert!(highlight_last_card == false);
+                            BorderStyling::Default
+                        }
+                        Some(GameCursorMode::PileSelect(_)) => match cursor.pile_index() {
+                            Some(index) if index == this_pile_index => BorderStyling::Dim,
+                            _ => BorderStyling::Default,
+                        },
+                        None => {
+                            assert!(false);
+                            BorderStyling::Default
+                        }
+                    },
+                },
+            }
         };
 
         ascii_cards.push(make_ascii_card(MakeAsciiCardParams {
@@ -87,6 +97,7 @@ enum BorderStyling {
     Default,
     Highlight,
     Dim,
+    Picked,
 }
 
 struct MakeAsciiCardParams<'a> {
@@ -217,6 +228,9 @@ fn calc_border_style(border_styling: BorderStyling) -> Style {
         BorderStyling::Default => Style::new(),
         BorderStyling::Highlight => Style::new().fg(Color::LightMagenta),
         BorderStyling::Dim => Style::new().add_modifier(Modifier::DIM),
+        BorderStyling::Picked => Style::new()
+            .add_modifier(Modifier::DIM)
+            .fg(Color::LightYellow),
     }
 }
 fn get_suit_color(suit: Suit) -> Color {

--- a/src/app/game_window/widgets/card_pile_widget/card_formatting.rs
+++ b/src/app/game_window/widgets/card_pile_widget/card_formatting.rs
@@ -46,14 +46,14 @@ pub fn make_card_pile_ascii_cards<'a>(
 
     for (card_index, card) in pile.cards().iter().enumerate() {
         let is_last = card_index == cards_len - 1;
-        let is_picked = if let Some(card_peek) = card_peek {
+        let is_peeked = if let Some(card_peek) = card_peek {
             card_peek.index == card_index
         } else {
             false
         };
 
-        let border_styling = if is_picked {
-            BorderStyling::Picked
+        let border_styling = if is_peeked {
+            BorderStyling::Peeked
         } else {
             match idx_card_highlight_start {
                 Some(highlight_start_idx) => match card_index >= highlight_start_idx {
@@ -87,6 +87,7 @@ pub fn make_card_pile_ascii_cards<'a>(
             card,
             border_styling,
             is_last,
+            is_peeked,
         }));
     }
 
@@ -97,24 +98,26 @@ enum BorderStyling {
     Default,
     Highlight,
     Dim,
-    Picked,
+    Peeked,
 }
 
 struct MakeAsciiCardParams<'a> {
     pub card: &'a Card,
     pub border_styling: BorderStyling,
     pub is_last: bool,
+    pub is_peeked: bool,
 }
 fn make_ascii_card(params: MakeAsciiCardParams) -> Text {
     let MakeAsciiCardParams {
         card,
         border_styling,
         is_last,
+        is_peeked,
     } = params;
 
     let border_style = calc_border_style(border_styling);
 
-    if card.is_opened {
+    if card.is_opened || is_peeked {
         make_ascii_opened_card(MakeAsciiOpenedCardParams {
             border_style,
             is_last,
@@ -228,7 +231,7 @@ fn calc_border_style(border_styling: BorderStyling) -> Style {
         BorderStyling::Default => Style::new(),
         BorderStyling::Highlight => Style::new().fg(Color::LightMagenta),
         BorderStyling::Dim => Style::new().add_modifier(Modifier::DIM),
-        BorderStyling::Picked => Style::new()
+        BorderStyling::Peeked => Style::new()
             .add_modifier(Modifier::DIM)
             .fg(Color::LightYellow),
     }

--- a/src/app/game_window/widgets/card_pile_widget/card_pile_widget.rs
+++ b/src/app/game_window/widgets/card_pile_widget/card_pile_widget.rs
@@ -4,7 +4,10 @@ use ratatui::{
     widgets::{List, StatefulWidget, Widget},
 };
 
-use crate::{app::game_window::game_cursor::GameCursor, game::v2::CardPileV2};
+use crate::{
+    app::game_window::game_cursor::GameCursor,
+    game::v2::{CardPeek, CardPileV2},
+};
 
 use super::{
     card_formatting::make_card_pile_ascii_cards,
@@ -16,11 +19,12 @@ use super::{
 #[derive(Clone, Copy)]
 pub struct CardPileWidget {
     cursor: GameCursor,
+    card_peek: Option<CardPeek>,
 }
 
 impl CardPileWidget {
-    pub fn new(cursor: GameCursor) -> Self {
-        Self { cursor }
+    pub fn new(cursor: GameCursor, card_peek: Option<CardPeek>) -> Self {
+        Self { cursor, card_peek }
     }
 }
 
@@ -44,7 +48,7 @@ impl StatefulWidget for CardPileWidget {
                     None
                 },
             });
-        let ascii_card_lines = make_card_pile_ascii_cards(&self.cursor, state);
+        let ascii_card_lines = make_card_pile_ascii_cards(&self.cursor, state, self.card_peek);
 
         let ascii_lines = ascii_card_lines
             .into_iter()

--- a/src/app/game_window/widgets/tableau_widget.rs
+++ b/src/app/game_window/widgets/tableau_widget.rs
@@ -9,7 +9,7 @@ use ratatui::{
 
 use crate::{
     app::game_window::game_cursor::GameCursor,
-    game::{core::PILES_AMOUNT, game_tableau::GameTableau},
+    game::{core::PILES_AMOUNT, game_tableau::GameTableau, v2::CardPeek},
 };
 
 use super::card_pile_widget::CardPileWidget;
@@ -17,11 +17,12 @@ use super::card_pile_widget::CardPileWidget;
 #[derive(Clone, Copy)]
 pub struct TableauWidget {
     cursor: GameCursor,
+    card_peeks: Option<[Option<CardPeek>; PILES_AMOUNT]>,
 }
 
 impl TableauWidget {
-    pub fn new(cursor: GameCursor) -> Self {
-        Self { cursor }
+    pub fn new(cursor: GameCursor, card_peeks: Option<[Option<CardPeek>; PILES_AMOUNT]>) -> Self {
+        Self { cursor, card_peeks }
     }
 }
 
@@ -34,6 +35,7 @@ impl StatefulWidget for TableauWidget {
     {
         let piles = &state.borrow().piles();
         let pile_w = (100 / PILES_AMOUNT) as u16;
+        let card_peeks = self.card_peeks.unwrap_or(std::array::from_fn(|_| None));
 
         for (pile_index, pile_area) in
             Layout::horizontal([Constraint::Percentage(pile_w)].repeat(PILES_AMOUNT))
@@ -42,8 +44,9 @@ impl StatefulWidget for TableauWidget {
                 .enumerate()
         {
             let pile = &mut piles.borrow_mut()[pile_index];
+            let card_peek = card_peeks[pile_index];
 
-            CardPileWidget::new(self.cursor).render(*pile_area, buf, pile);
+            CardPileWidget::new(self.cursor, card_peek).render(*pile_area, buf, pile);
         }
     }
 }

--- a/src/game/game_engine.rs
+++ b/src/game/game_engine.rs
@@ -5,8 +5,8 @@ use std::{cell::RefCell, rc::Rc};
 
 use super::{
     card_stock::ICardStock,
-    core::{COMPLETE_SEQUENCE_LENGTH, COMPLETE_SEQUENCES_TO_WIN, Card},
-    v2::CardMove,
+    core::{COMPLETE_SEQUENCE_LENGTH, COMPLETE_SEQUENCES_TO_WIN, Card, PILES_AMOUNT},
+    v2::{CardMove, CardPeek},
 };
 use crate::game::game_tableau::GameTableau;
 
@@ -40,6 +40,10 @@ impl<CardStockT: ICardStock> GameEngine<CardStockT> {
         } else {
             panic!("No deals left :(");
         }
+    }
+
+    pub fn get_card_peeks(&self) -> [Option<CardPeek>; PILES_AMOUNT] {
+        self.tableau.borrow().card_peeks()
     }
 
     pub fn get_available_moves(&self) -> Vec<CardMove> {

--- a/src/game/game_tableau.rs
+++ b/src/game/game_tableau.rs
@@ -144,7 +144,10 @@ mod tests {
         ]);
 
         let mut expected_moves = vec![
-            CardMoveBuilder::from_pile(0).to_card_pile(1).build(),
+            CardMoveBuilder::from_pile(0)
+                .using_card(0)
+                .to_card_pile(1)
+                .build(),
             CardMoveBuilder::from_pile(0)
                 .using_card(0)
                 .to_empty_pile(3)
@@ -173,7 +176,12 @@ mod tests {
             Card::new_opened(Rank::Three, Suit::Hearts),
         ]);
 
-        let expected_card_moves = vec![CardMoveBuilder::from_pile(0).to_card_pile(1).build()];
+        let expected_card_moves = vec![
+            CardMoveBuilder::from_pile(0)
+                .using_card(0)
+                .to_card_pile(1)
+                .build(),
+        ];
 
         let result_card_moves: Vec<CardMove> = tableau
             .calculate_available_moves()
@@ -210,8 +218,10 @@ mod tests {
         ]);
 
         let expected_card_moves = vec![
-            CardMoveBuilder::from_pile(0).to_card_pile(1).build(),
-            CardMoveBuilder::from_pile(1).to_card_pile(0).build(),
+            CardMoveBuilder::from_pile(0)
+                .using_card(2)
+                .to_card_pile(1)
+                .build(),
         ];
         let result_card_moves: Vec<CardMove> = tableau
             .calculate_available_moves()

--- a/src/game/game_tableau.rs
+++ b/src/game/game_tableau.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use super::{
     core::{COMPLETE_SEQUENCE_LENGTH, PILES_AMOUNT},
-    v2::{CardMove, CardMoveType, CardPileV2},
+    v2::{CardMove, CardMoveType, CardPeek, CardPileV2},
 };
 use crate::game::core::Card;
 
@@ -42,6 +42,22 @@ impl GameTableau {
             .for_each(|(pile, card)| {
                 pile.add_deal_card(*card);
             });
+    }
+
+    pub fn card_peeks(&self) -> [Option<CardPeek>; PILES_AMOUNT] {
+        let piles = self.piles.borrow();
+        let available_moves = self.calculate_available_moves();
+
+        std::array::from_fn(|pile_index| {
+            let pile = &piles[pile_index];
+            let pile_moves = available_moves
+                .iter()
+                .cloned()
+                .filter(|card_move| card_move.src_pile() == pile.index())
+                .collect::<Vec<_>>();
+
+            pile.calc_card_peek(&pile_moves)
+        })
     }
 
     pub fn extract_complete_sequences(&mut self) -> Vec<[Card; COMPLETE_SEQUENCE_LENGTH]> {
@@ -89,8 +105,8 @@ impl GameTableau {
             unsafe { &mut *(&mut self.piles.borrow_mut()[card_move.dest_pile()] as *mut _) };
 
         match card_move.move_type() {
-            CardMoveType::OnEmptyPile(src_card) => {
-                src_pile.perform_empty_pile_move(dest_pile, src_card)
+            CardMoveType::OnEmptyPile => {
+                src_pile.perform_empty_pile_move(dest_pile, card_move.src_card())
             }
             CardMoveType::OnCardPile => src_pile.perform_card_pile_move(dest_pile),
         }

--- a/src/game/v2/card_move.rs
+++ b/src/game/v2/card_move.rs
@@ -7,24 +7,30 @@ type SrcCardIndex = usize;
 type SrcPileIndex = usize;
 type DestPileIndex = usize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CardMoveType {
-    OnEmptyPile(SrcCardIndex),
+    OnEmptyPile = 1,
     OnCardPile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CardMove {
     move_type: CardMoveType,
+
     src: SrcPileIndex,
+    src_card_index: SrcCardIndex,
     dest: SrcPileIndex,
 }
 
 impl CardMove {
-    pub fn new_card_move(src: SrcPileIndex, dest: SrcPileIndex) -> Self {
+    pub fn new_card_move(
+        (src, src_card_index): (SrcPileIndex, SrcCardIndex),
+        dest: SrcPileIndex,
+    ) -> Self {
         Self {
             src,
             dest,
+            src_card_index,
             move_type: CardMoveType::OnCardPile,
         }
     }
@@ -35,7 +41,8 @@ impl CardMove {
         Self {
             src,
             dest,
-            move_type: CardMoveType::OnEmptyPile(src_card_index),
+            src_card_index,
+            move_type: CardMoveType::OnEmptyPile,
         }
     }
 
@@ -45,11 +52,8 @@ impl CardMove {
     pub fn dest_pile(&self) -> DestPileIndex {
         self.dest
     }
-    pub fn src_card(&self) -> Option<SrcCardIndex> {
-        match self.move_type {
-            CardMoveType::OnEmptyPile(card_index) => Some(card_index),
-            CardMoveType::OnCardPile => None,
-        }
+    pub fn src_card(&self) -> SrcCardIndex {
+        self.src_card_index
     }
     pub fn move_type(&self) -> CardMoveType {
         self.move_type
@@ -62,18 +66,23 @@ impl CardMove {
 /// -------- Formatting -------- ///
 impl fmt::Display for CardMove {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self.move_type {
-            CardMoveType::OnEmptyPile(card_index) => {
-                write!(
-                    f,
-                    "EmptyPileMove {{ {}->{}, card_idx={} }}",
-                    self.src, self.dest, card_index
-                )
+        write!(
+            f,
+            "{} {{ {}->{}, card_idx={} }}",
+            self.move_type, self.src, self.dest, self.src_card_index
+        )
+    }
+}
+impl fmt::Display for CardMoveType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                CardMoveType::OnEmptyPile => "OnEmptyPile",
+                CardMoveType::OnCardPile => "OnCardPile",
             }
-            CardMoveType::OnCardPile => {
-                write!(f, "CardPileMove {{ {}->{} }}", self.src, self.dest)
-            }
-        }
+        )
     }
 }
 
@@ -88,12 +97,7 @@ impl Ord for CardMove {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.src.cmp(&other.src) {
             Ordering::Equal => match self.dest.cmp(&other.dest) {
-                Ordering::Equal => match (self.move_type, other.move_type) {
-                    (CardMoveType::OnEmptyPile(a), CardMoveType::OnEmptyPile(b)) => a.cmp(&b),
-                    (CardMoveType::OnCardPile, CardMoveType::OnCardPile) => Ordering::Equal,
-                    (CardMoveType::OnEmptyPile(_), CardMoveType::OnCardPile) => Ordering::Less,
-                    (CardMoveType::OnCardPile, CardMoveType::OnEmptyPile(_)) => Ordering::Greater,
-                },
+                Ordering::Equal => self.move_type.cmp(&other.move_type),
                 ordering => ordering,
             },
             ordering => ordering,
@@ -133,12 +137,7 @@ impl CardMoveBuilder {
 
     pub fn to_empty_pile(mut self, dest_pile_index: DestPileIndex) -> Self {
         self.dest_pile_index = Some(dest_pile_index);
-        match self.src_card_index {
-            Some(src_card) => {
-                self.move_type = Some(CardMoveType::OnEmptyPile(src_card));
-            }
-            None => panic!("Please specify card before creating empty pile move!"),
-        }
+        self.move_type = Some(CardMoveType::OnEmptyPile);
 
         self
     }
@@ -147,18 +146,22 @@ impl CardMoveBuilder {
         if self.move_type.is_none() {
             panic!("No move type specified");
         }
+        if self.src_card_index.is_none() {
+            panic!("No src card specified");
+        }
         if self.dest_pile_index.is_none() {
             panic!("No dest pile specified");
         }
 
         match self.move_type.unwrap() {
-            CardMoveType::OnEmptyPile(card_index) => CardMove::new_pile_move(
-                (self.src_pile_index.unwrap(), card_index),
+            CardMoveType::OnEmptyPile => CardMove::new_pile_move(
+                (self.src_pile_index.unwrap(), self.src_card_index.unwrap()),
                 self.dest_pile_index.unwrap(),
             ),
-            CardMoveType::OnCardPile => {
-                CardMove::new_card_move(self.src_pile_index.unwrap(), self.dest_pile_index.unwrap())
-            }
+            CardMoveType::OnCardPile => CardMove::new_card_move(
+                (self.src_pile_index.unwrap(), self.src_card_index.unwrap()),
+                self.dest_pile_index.unwrap(),
+            ),
         }
     }
 }

--- a/src/game/v2/card_peek.rs
+++ b/src/game/v2/card_peek.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+
+use crate::game::core::Card;
+
+#[derive(Debug, Clone, Copy)]
+pub struct CardPeek {
+    pub index: usize,
+    pub card: Card,
+}
+impl CardPeek {
+    pub fn with_card_at_index(card: Card, index: usize) -> Self {
+        assert!(!card.is_opened);
+
+        Self { card, index }
+    }
+}

--- a/src/game/v2/card_pile.rs
+++ b/src/game/v2/card_pile.rs
@@ -2,7 +2,10 @@
 
 use std::fmt;
 
-use super::card_move::{CardMove, CardMoveBuilder};
+use super::{
+    card_move::{CardMove, CardMoveBuilder},
+    card_peek::CardPeek,
+};
 use crate::game::core::{COMPLETE_SEQUENCE_LENGTH, Card, PILES_AMOUNT};
 
 const NO_CARDS: [Card; 0] = [];
@@ -56,7 +59,36 @@ impl CardPileV2 {
         self.cards.push(card);
     }
 
-    pub fn open_last_card(&mut self) {
+    /**
+     * Assuming moves are this-pile from only.
+     *
+     * Return last closed card (if several conditions are met).
+     *
+     * Basically it's just "Undo" functionality abuse replacement
+     */
+    pub fn calc_card_peek(&self, pile_moves: &Vec<CardMove>) -> Option<CardPeek> {
+        assert!(pile_moves.iter().all(|pile| pile.src_pile() == self.index));
+
+        let has_peekable_move = pile_moves.iter().any(|card_move| card_move.src_card() == 0);
+
+        if !has_peekable_move {
+            return None;
+        }
+
+        let non_playable_cards = self.non_playable_cards();
+
+        if let Some((card_index, card)) = non_playable_cards.iter().enumerate().last() {
+            if !card.is_opened {
+                Some(CardPeek::with_card_at_index(*card, card_index))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn open_last_card(&mut self) {
         if let Some(last_card) = self.cards.last_mut() {
             last_card.is_opened = true;
         }
@@ -127,50 +159,35 @@ impl CardPileV2 {
         self.playable_cards().len()
     }
 
-    pub fn calc_moves_to(&self, other: &CardPileV2) -> Vec<CardMove> {
+    pub fn calc_moves_to(&self, other_pile: &CardPileV2) -> Vec<CardMove> {
         let cards = self.playable_cards();
-        let other_cards = other.playable_cards();
 
-        if !self.can_move_to(other) {
+        if cards.is_empty() {
             return vec![];
-        }
-
-        if other_cards.is_empty() {
+        } else if let Some(last_other_pile_card) = other_pile.playable_cards().last() {
+            cards
+                .iter()
+                .enumerate()
+                .filter(|(_, card)| card.can_move_on(last_other_pile_card))
+                .map(|(card_index, _)| {
+                    CardMoveBuilder::from_pile(self.index)
+                        .using_card(card_index)
+                        .to_card_pile(other_pile.index)
+                        .build()
+                })
+                .collect()
+        } else {
             cards
                 .iter()
                 .enumerate()
                 .map(|(index, _)| {
                     CardMoveBuilder::from_pile(self.index)
                         .using_card(index)
-                        .to_empty_pile(other.index)
+                        .to_empty_pile(other_pile.index)
                         .build()
                 })
                 .collect()
-        } else {
-            vec![
-                CardMoveBuilder::from_pile(self.index)
-                    .to_card_pile(other.index)
-                    .build(),
-            ]
         }
-    }
-
-    fn can_move_to(&self, other: &CardPileV2) -> bool {
-        let cards = self.playable_cards();
-        let other_cards = other.playable_cards();
-
-        if cards.is_empty() {
-            return false;
-        }
-        if other_cards.is_empty() {
-            return true;
-        }
-
-        cards.iter().any(|card| {
-            other_cards
-                .iter()
-                .any(|other_card| card.can_move_on(other_card))
-        })
     }
 
     fn extract_playable_cards_from(&mut self, index: usize) -> Vec<Card> {

--- a/src/game/v2/mod.rs
+++ b/src/game/v2/mod.rs
@@ -1,5 +1,7 @@
 mod card_move;
+mod card_peek;
 mod card_pile;
 
 pub use card_move::*;
+pub use card_peek::*;
 pub use card_pile::CardPileV2;


### PR DESCRIPTION
Press `p` to peek some cards (which you could abuse with 'undo' in regular solitaire).

You still not able to see card stock.
You cannot undo move made by mistake.

Let's say it's special feature. Makes undo abuse easier.
When I'll add moves count I'll consider peek as several moves per once.
Maybe I'll add max peek per game amount.
Maybe I'll add more custom funny stuff like that and rename it to "Solitail" or smth.
It's my personal project after all.

🏁 🏁 🏁